### PR TITLE
Grammar Correction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -176,7 +176,7 @@ version 2.76
 	    in the wild PXE clients which have problems with PXE
 	    boot menus. To work around this, when there's a single
 	    --pxe-service which applies to client, then that target
-	    will be booted directly, rather then sending a
+	    will be booted directly, rather than sending a
 	    single-item boot menu.
 
             Many thanks to Jarek Polok, Michael Kuron and Dreamcat4 
@@ -193,7 +193,7 @@ version 2.76
 	    The new behaviour is the same as the old, except when
 	    <basename> includes a file suffix, in which case
 	    the layer suffix is no longer added. This allows
-	    sensible suffices to be used, rather then the
+	    sensible suffices to be used, rather than the
 	    meaningless ".0". Only in the unlikely event that you
 	    have a config with a basename which already has a
 	    suffix, is this an incompatible change, since the file

--- a/CHANGELOG.archive
+++ b/CHANGELOG.archive
@@ -73,7 +73,7 @@ release 0.98  Some enhancements and bug-fixes.
               (3) Dnsmasq should now forward (but not cache) inverse queries 
                   and server status queries; this feature has not been tested.
               (4) Don't write the pid file when in non-daemon mode.
-	      (5) Create the pid file mode 644, rather then 666 (!).
+	      (5) Create the pid file mode 644, rather than 666 (!).
               (6) Generate queries to upstream nameservers with unpredictable
                   ids, to thwart DNS spoofers.
               (7) Dnsmasq no longer forwards queries when the 
@@ -205,7 +205,7 @@ release 1.2   Added IPv6 DNS record support. AAAA records are cached
               compilation on non-linux systems.
 
 release 1.3   Some versions of the Linux kernel return EINVAL rather
-              then ENPROTONOSUPPORT when IPv6 is not available, 
+              than ENPROTONOSUPPORT when IPv6 is not available, 
               causing dnsmasq to bomb out. This release fixes that.
               Thanks to Steve Davis for pointing this one out.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -62,7 +62,7 @@ dnsmasq (2.76-1) unstable; urgency=low
    * New upstream. (closes: #798586)
    * Use /run/dnsmasq directly, rather than relying on link from /var/run
      to avoid problems before /var is mounted. (closes: #800351)
-   * Test for the existence of /usr/share/doc/dnsmasq rather then
+   * Test for the existence of /usr/share/doc/dnsmasq rather than
      /etc/dnsmasq.d/README in the daemon startup script. (closes: #819856)
    * Add --help to manpage and mention dhcp6 in summary. (closes: #821226)
 

--- a/dnsmasq.conf.example
+++ b/dnsmasq.conf.example
@@ -146,7 +146,7 @@
 # Set a different domain for a particular subnet
 #domain=wireless.thekelleys.org.uk,192.168.2.0/24
 
-# Same idea, but range rather then subnet
+# Same idea, but range rather than subnet
 #domain=reserved.thekelleys.org.uk,192.68.3.100,192.168.3.200
 
 # Uncomment this to enable the integrated DHCP server, you need


### PR DESCRIPTION
While running etc-update today I noticed that the updated dnsmasq.conf had replaced "rather than", which is correct, with "rather then", which is incorrect. A search of the repository revealed the use of "rather then" in several more places.