### PR TITLE
skip loacl variable in dhcp_netid_free when reload dnsmasq config

### DIFF
--- a/src/dnsmasq.h
+++ b/src/dnsmasq.h
@@ -829,6 +829,8 @@ struct dhcp_lease {
 };
 
 struct dhcp_netid {
+  #define LOCAL_DHCP_NETID 1
+  unsigned int flags;
   char *net;
   struct dhcp_netid *next;
 };

--- a/src/option.c
+++ b/src/option.c
@@ -1107,6 +1107,9 @@ static void dhcp_netid_free(struct dhcp_netid *nid)
     {
       struct dhcp_netid *tmp = nid;
       nid = nid->next;
+	  if (tmp->flags & LOCAL_DHCP_NETID) {
+		  continue;
+	  }
       free(tmp->net);
       free(tmp);
     }

--- a/src/rfc2131.c
+++ b/src/rfc2131.c
@@ -107,6 +107,10 @@ size_t dhcp_reply(struct dhcp_context *context, char *iface_name, int int_index,
   subnet_addr.s_addr = override.s_addr = 0;
 
   /* set tag with name == interface */
+  known_id.flags = LOCAL_DHCP_NETID;
+  iface_id.flags = LOCAL_DHCP_NETID;
+  cpewan_id.flags = LOCAL_DHCP_NETID;
+
   iface_id.net = iface_name;
   iface_id.next = NULL;
   netid = &iface_id; 


### PR DESCRIPTION
Test on version 2.86, 
`# ps aux | grep dns
nobody   117520  0.0  0.0   6796   864 ?        S    18:34   0:00 /usr/local/zstack/dnsmasq --conf-file=/var/lib/zstack/dnsmasq/br_eth0_20accb7db1af4070b31ae6b18af15d57/dnsmasq.conf -K
[root@172-24-192-245 ~]# cat /var/lib/zstack/dnsmasq/br_eth0_20accb7db1af4070b31ae6b18af15d57/dnsmasq.conf
domain-needed
bogus-priv
no-hosts
addn-hosts=/var/lib/zstack/dnsmasq/br_eth0_20accb7db1af4070b31ae6b18af15d57/hosts.dns
dhcp-option=vendor:MSFT,2,1i
dhcp-lease-max=65535
dhcp-hostsfile=/var/lib/zstack/dnsmasq/br_eth0_20accb7db1af4070b31ae6b18af15d57/hosts.dhcp
dhcp-optsfile=/var/lib/zstack/dnsmasq/br_eth0_20accb7db1af4070b31ae6b18af15d57/hosts.option
log-facility=/var/lib/zstack/dnsmasq/br_eth0_20accb7db1af4070b31ae6b18af15d57/dnsmasq.log
interface=inner1
except-interface=lo
bind-interfaces
leasefile-ro
dhcp-range=172.24.0.1,static
# cat /var/lib/zstack/dnsmasq/br_eth0_20accb7db1af4070b31ae6b18af15d57/hosts.dhcp
fa:32:c4:95:ae:00,set:fa32c495ae00,172.24.24.10,172-24-24-10,infinite
fa:43:23:f9:c1:00,set:fa4323f9c100,172.24.24.13,172-24-24-13,infinite
`
reboot vm 172.24.24.13, then kill -1 $dnsmasq， dnsmasq will segfault.
